### PR TITLE
Add local fallback for progress tracking

### DIFF
--- a/src/utils/localProgress.js
+++ b/src/utils/localProgress.js
@@ -1,0 +1,21 @@
+export const saveProgressLocal = (userId, progress) => {
+  try {
+    const key = `progress_${userId}`;
+    localStorage.setItem(key, JSON.stringify(progress));
+    return true;
+  } catch (err) {
+    console.error('Lỗi khi lưu tiến độ local:', err);
+    return false;
+  }
+};
+
+export const getProgressLocal = (userId) => {
+  try {
+    const key = `progress_${userId}`;
+    const data = localStorage.getItem(key);
+    return data ? JSON.parse(data) : null;
+  } catch (err) {
+    console.error('Lỗi khi lấy tiến độ local:', err);
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary
- add utility to save progress in localStorage
- update progress context to fallback to local storage when database is unavailable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6857f9234e808322b454dd4e330091bb